### PR TITLE
Update minifier-rs version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 [dependencies]
 html-escape = "0.2"
 cow-utils = "0.1"
-minifier = "0.0.39"
+minifier = "0.0.40"
 
 [dependencies.educe]
 version = ">=0.4"


### PR DESCRIPTION
Minifier-rs version have been updated in order to retrieve the fix for a
bug when CSS contained empty comments

closes #9 