### PR TITLE
Add `module` as a javascript script type

### DIFF
--- a/src/html_minifier_helper.rs
+++ b/src/html_minifier_helper.rs
@@ -129,7 +129,7 @@ impl HTMLMinifierHelper {
                 self.step_counter = 0;
 
                 match self.attribute_type.as_slice() {
-                    b"" | b"application/javascript" => {
+                    b"" | b"application/javascript" | b"module" => {
                         out.push_bytes(&text_bytes[*start..=p])?;
                         *start = p + 1;
 


### PR DESCRIPTION
HTML5 introduced the `module` type in the `script` tag but it appears that it is not filtered as JavaScript currently, so I added it, as a `module` is always guaranteed to be JavaScript.

One potential issue is whether the underlying javascript minification framework supports JS modules.